### PR TITLE
Responsive design improvements for screens wider than 1200px, 1600px, and 2000px

### DIFF
--- a/assets/css/partials/_breakpoints.scss
+++ b/assets/css/partials/_breakpoints.scss
@@ -94,3 +94,36 @@
         width: 100%;
     }
 }
+
+@include media(1200px) {
+    .content-container {
+        max-width: 1200px;
+    }
+}
+
+@include media(1600px) {
+    .content-container {
+        max-width: 1400px;
+    }
+
+    body {
+        font-size: 110%;
+    }
+}
+
+@include media(2000px) {
+    .content-container {
+        max-width: 1600px;
+        margin-left: 340px;
+    }
+
+    // Slightly adjust sidebar width because text size increases
+    nav {
+        width: 270px;
+    }
+
+    body {
+        font-size: 120%;
+    }
+}
+

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -7,7 +7,7 @@
   {{ end }}
   {{ $rssOutput := .OutputFormats.Get "RSS" }}
   {{ if $rssOutput }}
-    <a href="{{ $rssOutput.Permalink }}">RSS</a>
+    <a class="color-link nav-link" href="{{ $rssOutput.Permalink }}" target="_blank" rel="noopener" type="application/rss+xml">RSS</a>
   {{ end }}
 </div>
 {{ partial "footer.html" . }}


### PR DESCRIPTION
This pull request improves the site's responsiveness and accessibility by updating CSS breakpoints for better layout scaling on large screens and enhancing the RSS link in the navigation for better usability and security.

**Responsive layout improvements:**

* Added new media queries in `_breakpoints.scss` to adjust `.content-container` width, font sizes, and sidebar (`nav`) width for screen sizes at 1200px, 1600px, and 2000px, ensuring the layout scales more gracefully on larger displays.

**Accessibility and usability enhancements:**

* Updated the RSS link in `nav.html` to open in a new tab, use a more descriptive class, and include proper attributes for security and content type.